### PR TITLE
Add a pthreads fallback for thread_local

### DIFF
--- a/include/thread-capture.h
+++ b/include/thread-capture.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <cassert>
 
 #include "thread-crosser.h"
+#include "thread-local.h"
 
 namespace capture_thread {
 
@@ -159,7 +160,9 @@ class ThreadCapture {
   virtual ~ThreadCapture() = default;
 
   // Gets the most-recent object from the stack of the current thread.
-  static inline Type* GetCurrent() { return current_; }
+  static inline Type* GetCurrent() {
+    return ThreadLocal<Type>::GetCurrentThreadValue();
+  }
 
  private:
   ThreadCapture(const ThreadCapture&) = delete;
@@ -168,9 +171,9 @@ class ThreadCapture {
   ThreadCapture& operator=(ThreadCapture&&) = delete;
   void* operator new(std::size_t size) = delete;
 
-  static inline void SetCurrent(Type* value) { current_ = value; }
-
-  static thread_local Type* current_;
+  static inline void SetCurrent(Type* value) {
+    ThreadLocal<Type>::SetCurrentThreadValue(value);
+  }
 };
 
 template <class Type>

--- a/include/thread-local.h
+++ b/include/thread-local.h
@@ -1,0 +1,76 @@
+#ifndef THIRD_PARTY_CAPTURE_THREAD_THREAD_LOCAL_H_
+#define THIRD_PARTY_CAPTURE_THREAD_THREAD_LOCAL_H_
+
+// Use thread_local by default
+#if !defined(THREAD_CAPTURE_USE_PTHREAD) && \
+    !defined(THREAD_CAPTURE_USE_THREAD_LOCAL)
+#define THREAD_CAPTURE_USE_THREAD_LOCAL
+#endif
+
+#if defined(THREAD_CAPTURE_USE_PTHREAD)
+#include <pthread.h>
+#endif
+
+namespace capture_thread {
+
+// Private class for implementing static thread local storage. It allows falling
+// back to using pthreads on platforms that don't support the thread_local
+// keyword.
+template <typename Type>
+class ThreadLocal {
+ public:
+  static Type* GetCurrentThreadValue();
+  static void SetCurrentThreadValue(Type* value);
+
+ private:
+  ThreadLocal();
+  ~ThreadLocal();
+  ThreadLocal(const ThreadLocal&) = delete;
+  ThreadLocal& operator=(const ThreadLocal&) = delete;
+
+#if defined(THREAD_CAPTURE_USE_THREAD_LOCAL)
+  static thread_local Type* value_;
+#elif THREAD_CAPTURE_USE_PTHREAD
+  static pthread_key_t GetKey();
+  static pthread_key_t key_;
+#endif
+};
+
+#if defined(THREAD_CAPTURE_USE_THREAD_LOCAL)
+template <typename Type>
+thread_local Type* ThreadLocal<Type>::value_(nullptr);
+
+template <typename Type>
+Type* ThreadLocal<Type>::GetCurrentThreadValue() {
+  return value_;
+}
+
+template <typename Type>
+void ThreadLocal<Type>::SetCurrentThreadValue(Type* value) {
+  value_ = value;
+}
+#elif THREAD_CAPTURE_USE_PTHREAD
+
+template <typename Type>
+pthread_key_t ThreadLocal<Type>::GetKey() {
+  // Always get the key through this function so pthread_key_create can be
+  // delayed until the first set/get.
+  static int key_create_result __attribute__((__unused__)) =
+      pthread_key_create(&key_, [](void*) { pthread_key_delete(key_); });
+  return key_;
+}
+
+template <typename Type>
+Type* ThreadLocal<Type>::GetCurrentThreadValue() {
+  return static_cast<Type*>(pthread_getspecific(GetKey()));
+}
+
+template <typename Type>
+void ThreadLocal<Type>::SetCurrentThreadValue(Type* value) {
+  pthread_setspecific(GetKey(), value);
+}
+#endif
+
+}  // namespace capture_thread
+
+#endif  // THIRD_PARTY_CAPTURE_THREAD_THREAD_LOCAL_H_

--- a/src/thread-crosser.cc
+++ b/src/thread-crosser.cc
@@ -17,17 +17,18 @@ limitations under the License.
 // Author: Kevin P. Barry [ta0kira@gmail.com] [kevinbarry@google.com]
 
 #include "thread-crosser.h"
+#include "thread-local.h"
 
 namespace capture_thread {
 
-namespace {
-thread_local ThreadCrosser* current(nullptr);
+// static
+ThreadCrosser* ThreadCrosser::GetCurrent() {
+  return ThreadLocal<ThreadCrosser>::GetCurrentThreadValue();
 }
 
 // static
-ThreadCrosser* ThreadCrosser::GetCurrent() { return current; }
-
-// static
-void ThreadCrosser::SetCurrent(ThreadCrosser* value) { current = value; }
+void ThreadCrosser::SetCurrent(ThreadCrosser* value) {
+  ThreadLocal<ThreadCrosser>::SetCurrentThreadValue(value);
+}
 
 }  // namespace capture_thread


### PR DESCRIPTION
Some platforms don't properly support thread_local (https://github.com/android-ndk/ndk/issues/8). So this adds a pthread based work around. It still defaults to using thread_local.